### PR TITLE
changing arrow from span to div

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-reveal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": "git://github.com/LearningPool/adapt-contrib-reveal.git",
   "homepage": "https://github.com/LearningPool/adapt-contrib-reveal",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-reveal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A component which allows alternating images and/or text to be revealed",
   "main": "",
   "scripts": {

--- a/templates/reveal.hbs
+++ b/templates/reveal.hbs
@@ -39,6 +39,6 @@
                 {{/if}}
             </div>
         </div>
-        <a href="#" class="reveal-widget-control"><span class="reveal-widget-icon icon"></span></a>
+        <a href="#" class="reveal-widget-control"><div class="reveal-widget-icon icon"></div></a>
     </div>
 </div>


### PR DESCRIPTION
The direction arrow was not displaying in ie8 because span's are set to `opacity: 0;` this gets round the issue 