### PR TITLE
Adapt 5387 - reveal arrow cut off on mobile devices

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-reveal",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "repository": "git://github.com/LearningPool/adapt-contrib-reveal.git",
   "homepage": "https://github.com/LearningPool/adapt-contrib-reveal",
   "authors": [

--- a/less/reveal.less
+++ b/less/reveal.less
@@ -39,7 +39,6 @@
 
     .reveal-image {
         display: block;
-        min-height: 50px;
     }
 
     .reveal-image.reveal-right {

--- a/less/reveal.less
+++ b/less/reveal.less
@@ -9,6 +9,8 @@
         position: absolute;
         text-align: center;
         top: 50%;
+        // Needed to override icons.less
+        transform: translateY(-50%) !important;
         vertical-align: middle;
         width: 100%;
 
@@ -37,6 +39,7 @@
 
     .reveal-image {
         display: block;
+        min-height: 50px;
     }
 
     .reveal-image.reveal-right {


### PR DESCRIPTION
On narrow images the arrow was not being fully displayed.